### PR TITLE
Suppress edit event if text has been selected

### DIFF
--- a/2click2editwiki/plugins/2click2edit/clickListener.js
+++ b/2click2editwiki/plugins/2click2edit/clickListener.js
@@ -37,7 +37,9 @@ ClickListener.prototype.render = function(parent,nextSibling) {
 };
 
 ClickListener.prototype.editTiddler = function(event) {
-    this.dispatchEvent({type: "tm-edit-tiddler", param: this.getVariable("currentTiddler")});    
+	if (getSelection().toString().trim().length == 0) {
+		this.dispatchEvent({ type: "tm-edit-tiddler", param: this.getVariable("currentTiddler") });
+	}
 };
 
 /*


### PR DESCRIPTION
This PR distinguishes between a double-click for word/line selection and double-click for edit. If text is selected, the edit event is skipped.